### PR TITLE
Implement clickable links

### DIFF
--- a/UnitedChat/src/main/java/org/unitedlands/unitedchat/player/PlayerListener.java
+++ b/UnitedChat/src/main/java/org/unitedlands/unitedchat/player/PlayerListener.java
@@ -110,7 +110,7 @@ public class PlayerListener implements Listener {
         return ChatColor.translateAlternateColorCodes('&', string);
     }
 
-    public static boolean isURL(String url) {
+    private boolean isURL(String url) {
         try {
             new URL(url);
             return true;


### PR DESCRIPTION
This adds in a small check to see if a message part is a valid url (https://google.com for example). If it is, it makes the link automatically clickable, highlights to the same color as discord's url links (#10afee), and adds a fancy underline.