### PR TITLE
Code cleanup, reformat, and refactoring - Final Stretch. 

### DIFF
--- a/UnitedWars/src/main/java/org/unitedlands/wars/UnitedWars.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/UnitedWars.java
@@ -1,7 +1,6 @@
 package org.unitedlands.wars;
 
 import com.palmergames.bukkit.towny.TownyAPI;
-import me.clip.placeholderapi.PlaceholderAPI;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -46,7 +45,7 @@ public final class UnitedWars extends JavaPlugin {
     }
 
     private void registerListeners() {
-        registerListener(new WarListener(this));
+        registerListener(new WarListener());
         registerListener(new PlayerListener(this));
         registerListener(new BookListener(this));
     }

--- a/UnitedWars/src/main/java/org/unitedlands/wars/Utils.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/Utils.java
@@ -11,9 +11,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.*;
 
 import static org.unitedlands.wars.UnitedWars.MINI_MESSAGE;
 
@@ -69,6 +67,14 @@ public class Utils {
     public static Town getPlayerTown(UUID uuid) {
         Resident resident = getTownyResident(uuid);
         return resident.getTownOrNull();
+    }
+
+    public static HashSet<UUID> toUUID(Collection<Resident> residents) {
+        HashSet<UUID> uuids = new HashSet<>();
+        for (Resident resident: residents) {
+            uuids.add(resident.getUUID());
+        }
+        return uuids;
     }
 
     public static Resident getTownyResident(Player player) {

--- a/UnitedWars/src/main/java/org/unitedlands/wars/books/TokenCostCalculator.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/books/TokenCostCalculator.java
@@ -52,15 +52,15 @@ public class TokenCostCalculator {
     }
 
     public int calculateWarCost() {
-        int baseCost = getBaseCost();
+        int baseCost = type.getBaseCost();
 
         // Increase token cost by 10 percent
         final double riseStep = 0.10;
         // Rise every 100 claimed chunks
         final double riseAt = 100;
 
-        // Decrease token cost by 25 percent
-        final double fallStep = 0.25;
+        // Decrease token cost by 15 percent
+        final double fallStep = 0.15;
         // Decrease every 8 hostility points in a town
         final double fallAt = 8;
 
@@ -70,13 +70,8 @@ public class TokenCostCalculator {
         double riseMod = (riseStep * targetSizeStep) + 1;
         double fallMod = (fallStep * targetHostilityStep) + 1;
 
-
         int calculatedCost = (int) Math.floor((baseCost * riseMod) / fallMod);
         return Math.max(10, calculatedCost);
-    }
-
-    private int getBaseCost() {
-        return type.getBaseCost();
     }
 
     private int getTotalTargetHostility() {

--- a/UnitedWars/src/main/java/org/unitedlands/wars/books/data/Declarer.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/books/data/Declarer.java
@@ -2,43 +2,47 @@ package org.unitedlands.wars.books.data;
 
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.unitedlands.wars.UnitedWars;
 import org.unitedlands.wars.Utils;
 
+import java.util.UUID;
+
 public class Declarer {
-    private final Player declaringPlayer;
-    private final Town town;
-    private final Nation nation;
+    private final UUID declaringPlayer;
+    private final UUID town;
+    private final UUID nation;
 
 
     public Declarer(Player declaringPlayer) {
-        this.declaringPlayer = declaringPlayer;
-        town = Utils.getPlayerTown(declaringPlayer);
-        if (town.hasNation())
-            nation = town.getNationOrNull();
+        this.declaringPlayer = declaringPlayer.getUniqueId();
+        town = Utils.getPlayerTown(declaringPlayer).getUUID();
+        if (town().hasNation())
+            nation = town().getNationOrNull().getUUID();
         else
             nation = null;
     }
 
     public Declarer(Town town) {
-        this.town = town;
-        this.declaringPlayer = town.getMayor().getPlayer();
+        this.town = town.getUUID();
+        this.declaringPlayer = town().getMayor().getUUID();
         if (town.hasNation())
-            nation = town.getNationOrNull();
+            nation = town().getNationOrNull().getUUID();
         else
             nation = null;
     }
 
     public Player player() {
-        return declaringPlayer;
+        return Bukkit.getPlayer(declaringPlayer);
     }
 
     public Town town() {
-        return town;
+        return UnitedWars.TOWNY_API.getTown(town);
     }
 
     public Nation nation() {
-        return nation;
+        return UnitedWars.TOWNY_API.getNation(nation);
     }
 
 }

--- a/UnitedWars/src/main/java/org/unitedlands/wars/books/data/WarTarget.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/books/data/WarTarget.java
@@ -4,50 +4,48 @@ import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Town;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
+import org.unitedlands.wars.UnitedWars;
 import org.unitedlands.wars.war.WarType;
 
 import java.util.UUID;
 
 public class WarTarget {
-    private final OfflinePlayer targetMayor;
-    private final Town town;
-    private final Nation nation;
+    private final UUID targetMayor;
+    private final UUID town;
+    private final UUID nation;
     private final WarType type;
 
 
     public WarTarget(Town town) {
-        this.town = town;
-        targetMayor = Bukkit.getOfflinePlayer(town.getMayor().getUUID());
+        this.town = town.getUUID();
+        targetMayor = town.getMayor().getUUID();
         type = WarType.TOWNWAR;
         if (town.hasNation())
-            nation = town.getNationOrNull();
+            nation = town.getNationOrNull().getUUID();
         else
             nation = null;
     }
 
     public WarTarget(Nation nation) {
-        this.nation = nation;
-        this.town = nation.getCapital();
+        this.nation = nation.getUUID();
+        this.town = nation.getCapital().getUUID();
         type = WarType.NATIONWAR;
-        targetMayor = Bukkit.getOfflinePlayer(town.getMayor().getUUID());
+        targetMayor = town().getMayor().getUUID();
     }
 
     public OfflinePlayer targetMayor() {
-        return targetMayor;
+        return Bukkit.getPlayer(targetMayor);
     }
 
     public Town town() {
-        return town;
+        return UnitedWars.TOWNY_API.getTown(town);
     }
 
     public Nation nation() {
-        return nation;
+        return UnitedWars.TOWNY_API.getNation(nation);
     }
 
     public UUID uuid() {
-        if (type == WarType.NATIONWAR)
-            return nation.getUUID();
-        else
-            return town.getUUID();
+        return type == WarType.NATIONWAR ? nation : town;
     }
 }

--- a/UnitedWars/src/main/java/org/unitedlands/wars/books/generators/BookGenerator.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/books/generators/BookGenerator.java
@@ -143,36 +143,26 @@ public class BookGenerator {
     }
 
     private String getTownStat(String statName, Town town) {
-        switch (statName) {
-            case "blocks" -> {
-                return String.valueOf(town.getNumTownBlocks());
-            }
-            case "residents" -> {
-                return String.valueOf(town.getNumResidents());
-            }
-            case "balance" -> {
-                return String.valueOf(town.getAccount().getHoldingBalance());
-            }
-        }
-        return "0";
+        return switch (statName) {
+            case "blocks" -> String.valueOf(town.getNumTownBlocks());
+            case "residents" -> String.valueOf(town.getNumResidents());
+            case "balance" -> String.valueOf(town.getAccount().getHoldingBalance());
+            default -> "0";
+        };
     }
 
     private String getNationStat(String statName, Nation nation) {
-        switch (statName) {
-            case "blocks" -> {
-                return String.valueOf(nation.getTownBlocks().size());
-            }
-            case "residents" -> {
-                return String.valueOf(nation.getNumResidents());
-            }
+        return switch (statName) {
+            case "blocks" -> String.valueOf(nation.getTownBlocks().size());
+            case "residents" -> String.valueOf(nation.getNumResidents());
             case "balance" -> {
                 double totalBalance = nation.getAccount().getHoldingBalance();
                 for (Town town : nation.getTowns()) {
                     totalBalance += town.getAccount().getHoldingBalance();
                 }
-                return String.valueOf(totalBalance);
+                yield String.valueOf(totalBalance);
             }
-        }
-        return "0";
+            default -> "0";
+        };
     }
 }

--- a/UnitedWars/src/main/java/org/unitedlands/wars/books/generators/DeclarationGenerator.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/books/generators/DeclarationGenerator.java
@@ -16,7 +16,7 @@ import static net.kyori.adventure.text.Component.text;
 
 public class DeclarationGenerator extends BookGenerator {
     private final DeclarationWarBook declarationBook;
-    private ItemStack bookItem = new ItemStack(Material.WRITTEN_BOOK);
+    private final ItemStack bookItem = new ItemStack(Material.WRITTEN_BOOK);
     private BookMeta bookMeta = (BookMeta) bookItem.getItemMeta();
 
     public DeclarationGenerator(DeclarationWarBook declarationBook) {

--- a/UnitedWars/src/main/java/org/unitedlands/wars/commands/DeclareCommandParser.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/commands/DeclareCommandParser.java
@@ -1,7 +1,6 @@
 package org.unitedlands.wars.commands;
 
 import com.palmergames.bukkit.towny.TownyAPI;
-import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.confirmations.Confirmation;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
@@ -64,18 +63,17 @@ public class DeclareCommandParser {
            return;
         }
         Confirmation.runOnAccept(() -> {
-
             if (!testBookRequirementsAreMet(WarType.TOWNWAR))
                 return;
 
             if (targetTown.isNeutral()) {
-                TownyMessaging.sendErrorMsg(this.sender, new Translatable[]{Translatable.of("msg_err_cannot_declare_war_on_neutral")});
+                player.sendMessage(getMessage("must-not-be-neutral-target"));
                 return;
             }
             Resident resident = UnitedWars.TOWNY_API.getResident(player);
             Town town = resident.getTownOrNull();
             if (!townsHaveEnoughOnline(targetTown, town)) {
-                TownyMessaging.sendErrorMsg(this.sender, new Translatable[]{Translatable.of("msg_err_not_enough_people_online_for_townwar", 1)});
+                player.sendMessage(getMessage("must-have-online-player"));
                 return;
             }
             List<Town> towns = new ArrayList<>();
@@ -187,7 +185,7 @@ public class DeclareCommandParser {
 
     private WarType getWarType() {
         PersistentDataContainer pdc = getHeldBookData();
-        String storedTypeName = pdc.get(NamespacedKey.fromString("unitedwars.book.type"), PersistentDataType.STRING);
+        String storedTypeName = pdc.get(TYPE_KEY, PersistentDataType.STRING);
         try {
             return WarType.valueOf(storedTypeName);
         } catch (Exception e) {

--- a/UnitedWars/src/main/java/org/unitedlands/wars/commands/surrender/SurrenderRequest.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/commands/surrender/SurrenderRequest.java
@@ -43,7 +43,6 @@ class SurrenderRequest {
         this.moneyAmount = moneyAmount;
         town = null;
         notifyTarget();
-
     }
 
     SurrenderRequest(UUID requester, UUID target, SurrenderType type, Town town) {

--- a/UnitedWars/src/main/java/org/unitedlands/wars/listeners/BookListener.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/listeners/BookListener.java
@@ -10,7 +10,7 @@ import org.bukkit.event.player.PlayerEditBookEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
-import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.unitedlands.wars.UnitedWars;
 import org.unitedlands.wars.books.declaration.DeclarationWarBook;
 import org.unitedlands.wars.books.declaration.NationDeclarationBook;
@@ -32,15 +32,16 @@ public class BookListener implements Listener {
         this.unitedWars = unitedWars;
     }
 
-    private static boolean isWritableDeclaration(PersistentDataContainer pdc) {
-        return WritableDeclaration.isWritableDeclaration(pdc);
+    private static boolean isWritableDeclaration(ItemMeta meta) {
+        return WritableDeclaration.isWritableDeclaration(meta.getPersistentDataContainer());
     }
 
     @EventHandler
     public void onBookEdit(PlayerEditBookEvent event) {
-        boolean isWritableDeclaration = isWritableDeclaration(event.getPreviousBookMeta().getPersistentDataContainer());
-        if (!isWritableDeclaration) return;
-        if (!event.isSigning()) return;
+        if (!isWritableDeclaration(event.getPreviousBookMeta()))
+            return;
+        if (!event.isSigning())
+            return;
 
         BookMeta bookMeta = event.getNewBookMeta();
         WritableDeclaration writableDeclaration = generateWritableDeclaration(bookMeta);
@@ -52,24 +53,26 @@ public class BookListener implements Listener {
 
         // Generate the sealed book.
         WarType type = writableDeclaration.getWarType();
-        DeclarationWarBook declarationBook = null;
-        if (type == WarType.TOWNWAR) {
+        DeclarationWarBook declarationBook;
+        if (type == WarType.TOWNWAR)
             declarationBook = new TownDeclarationBook(writableDeclaration);
-        } else if (type == WarType.NATIONWAR) {
+        else
             declarationBook = new NationDeclarationBook(writableDeclaration);
-        }
-
 
         // Replace the held item, the old book, with the new sealed book to be used for declaration.
         DeclarationWarBook finalDeclarationBook = declarationBook;
         unitedWars.getServer().getScheduler().runTask(unitedWars, () -> event.getPlayer().getInventory().setItemInMainHand(finalDeclarationBook.getBook()));
     }
 
+    private boolean canWriteBook(Resident resident, WritableDeclaration writableDeclaration) {
+        return resident.getTownOrNull().equals(writableDeclaration.getDeclarer().town()) && resident.isMayor();
+    }
+
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onBookInteract(PlayerInteractEvent event) {
         ItemStack item = event.getItem();
         if (item == null) return;
-        if (!isWritableDeclaration(item.getItemMeta().getPersistentDataContainer())) return;
+        if (!isWritableDeclaration(item.getItemMeta())) return;
 
         Resident resident = getTownyResident(event.getPlayer());
         WritableDeclaration writableDeclaration = generateWritableDeclaration((BookMeta) item.getItemMeta());
@@ -79,9 +82,5 @@ public class BookListener implements Listener {
             event.getPlayer().sendMessage(getMessage("only-mayors-can-sign", Placeholder.component("declarer-name", text(writableDeclaration.getDeclarerName()))));
             event.getPlayer().closeInventory();
         }
-    }
-
-    private boolean canWriteBook(Resident resident, WritableDeclaration writableDeclaration) {
-        return resident.getTownOrNull().equals(writableDeclaration.getDeclarer().town()) && resident.isMayor();
     }
 }

--- a/UnitedWars/src/main/java/org/unitedlands/wars/listeners/PlayerListener.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/listeners/PlayerListener.java
@@ -35,11 +35,9 @@ import static org.unitedlands.wars.Utils.*;
 import static org.unitedlands.wars.war.WarUtil.hasSameWar;
 
 public class PlayerListener implements Listener {
-    private final UnitedWars unitedWars;
     private final FileConfiguration config;
 
     public PlayerListener(UnitedWars unitedWars) {
-        this.unitedWars = unitedWars;
         config = unitedWars.getConfig();
     }
 
@@ -119,11 +117,7 @@ public class PlayerListener implements Listener {
                     notifyWarKick(victim.getPlayer(), warringEntity);
                     return;
                 }
-                for (Resident resident : warringEntity.getWar().getResidents()) {
-                    if (resident.getPlayer() != null) {
-                        resident.getPlayer().sendMessage(message);
-                    }
-                }
+                warringEntity.getWar().broadcast(message);
             }
         }
     }
@@ -135,13 +129,8 @@ public class PlayerListener implements Listener {
 
         Component message = getMessage("removed-from-war",
                 component("victim-warrer", text(warringEntity.name())));
-        warringEntity.getWar().getResidents().forEach(resident -> {
-            if (resident.isOnline()) {
-                resident.getPlayer().sendMessage(message);
-            }
-        });
 
-
+        warringEntity.getWar().broadcast(message);
     }
 
     @NotNull
@@ -171,11 +160,7 @@ public class PlayerListener implements Listener {
                     component("victim", text(victim.getName())),
                     component("victim-warrer", text(warringEntity.name())));
 
-            for (Resident resident : warringEntity.getWar().getResidents()) {
-                if (resident.getPlayer() != null) {
-                    resident.getPlayer().sendMessage(message);
-                }
-            }
+            warringEntity.getWar().broadcast(message);
         }
     }
 

--- a/UnitedWars/src/main/java/org/unitedlands/wars/listeners/WarListener.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/listeners/WarListener.java
@@ -24,6 +24,7 @@ import org.unitedlands.wars.war.WarDatabase;
 import org.unitedlands.wars.war.WarUtil;
 import org.unitedlands.wars.war.entities.WarringEntity;
 
+import java.util.HashSet;
 import java.util.List;
 
 public class WarListener implements Listener {
@@ -152,7 +153,7 @@ public class WarListener implements Listener {
         notifyResidents(declarer.getOnlinePlayers(), declarationTitle);
     }
 
-    private void notifyResidents(List<Player> players, Title title) {
+    private void notifyResidents(HashSet<Player> players, Title title) {
         for (Player player : players) {
             player.showTitle(title);
             player.playSound(player, Sound.EVENT_RAID_HORN, 75, 1);

--- a/UnitedWars/src/main/java/org/unitedlands/wars/war/War.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/war/War.java
@@ -28,7 +28,7 @@ public class War {
     private static final UnitedWars plugin = UnitedWars.getInstance();
     private final List<WarringTown> warringTowns;
     private final List<WarringNation> warringNations;
-    private final HashSet<Resident> residents;
+    private final HashSet<UUID> residents;
     private final WarType warType;
     private UUID uuid = UUID.randomUUID();
     private WarTimer warTimer = null;
@@ -38,7 +38,7 @@ public class War {
     public War(List<Town> warringTowns, List<Nation> warringNations, HashSet<Resident> residents, WarType warType) {
         this.warringTowns = generateWarringTownList(warringTowns);
         this.warringNations = generateWarringNationList(warringNations);
-        this.residents = residents;
+        this.residents = Utils.toUUID(residents);
         this.warType = warType;
         warTimer = new WarTimer(this);
         // Start the war immediately, since this is the first time.
@@ -51,7 +51,7 @@ public class War {
     public War(List<Town> warringTowns, List<Nation> warringNations, HashSet<Resident> residents, WarType warType, UUID uuid) {
         this.warringTowns = generateWarringTownList(warringTowns);
         this.warringNations = generateWarringNationList(warringNations);
-        this.residents = residents;
+        this.residents = Utils.toUUID(residents);
         this.warType = warType;
         this.uuid = uuid;
         // Save war to internal database
@@ -76,8 +76,10 @@ public class War {
         return warringNations;
     }
 
-    public HashSet<Resident> getResidents() {
-        return residents;
+    public HashSet<Resident> getWarParticipants() {
+        HashSet<Resident> uuidResidents = new HashSet<>();
+        residents.forEach(uuid -> uuidResidents.add(Utils.getTownyResident(uuid)));
+        return uuidResidents;
     }
 
     public WarType getWarType() {
@@ -94,7 +96,7 @@ public class War {
 
     public HashSet<Player> getOnlinePlayers() {
         HashSet<Player> players = new HashSet<>();
-        getResidents().forEach(resident -> {
+        getWarParticipants().forEach(resident -> {
             if (resident.isOnline())
                 players.add(resident.getPlayer());
         });
@@ -181,7 +183,7 @@ public class War {
     }
 
     private void runPlayerProcedures() {
-        for (Resident resident : getResidents()) {
+        for (Resident resident : getWarParticipants()) {
             // Set player lives
             WarDataController.setResidentLives(resident, 3);
 

--- a/UnitedWars/src/main/java/org/unitedlands/wars/war/WarDataController.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/war/WarDataController.java
@@ -7,12 +7,12 @@ import com.palmergames.bukkit.towny.object.metadata.LongDataField;
 import com.palmergames.bukkit.towny.utils.MetaDataUtil;
 
 public class WarDataController {
-    private static final IntegerDataField residentLives = new IntegerDataField("unitedwars_residentLives", 0, "War Lives Remaining");
-    private static final IntegerDataField tokens = new IntegerDataField("unitedwars_tokens", 0, "War Tokens");
-    private static final LongDataField lastWarEndTime = new LongDataField("unitedwars_lastWarEndTime", 0L);
+    private static final IntegerDataField RESIDENT_LIVES = new IntegerDataField("unitedwars_residentLives", 0, "War Lives Remaining");
+    private static final IntegerDataField TOKENS = new IntegerDataField("unitedwars_tokens", 0, "War Tokens");
+    private static final LongDataField LAST_WAR_END_TIME = new LongDataField("unitedwars_lastWarEndTime", 0L);
 
     public static int getResidentLives(Resident res) {
-        IntegerDataField idf = (IntegerDataField) residentLives.clone();
+        IntegerDataField idf = (IntegerDataField) RESIDENT_LIVES.clone();
         return res.hasMeta(idf.getKey()) ? MetaDataUtil.getInt(res, idf) : 0;
     }
 
@@ -21,7 +21,7 @@ public class WarDataController {
     }
 
     public static void setResidentLives(Resident res, int lives) {
-        IntegerDataField idf = (IntegerDataField) residentLives.clone();
+        IntegerDataField idf = (IntegerDataField) RESIDENT_LIVES.clone();
         if (res.hasMeta(idf.getKey())) {
             MetaDataUtil.setInt(res, idf, lives, true);
         } else {
@@ -31,7 +31,7 @@ public class WarDataController {
     }
 
     public static void decrementResidentLives(Resident res) {
-        IntegerDataField idf = (IntegerDataField) residentLives.clone();
+        IntegerDataField idf = (IntegerDataField) RESIDENT_LIVES.clone();
         if (res.hasMeta(idf.getKey())) {
             MetaDataUtil.setInt(res, idf, getResidentLives(res) - 1, true);
         }
@@ -39,17 +39,8 @@ public class WarDataController {
         res.save();
     }
 
-    public static void incrementResidentLives(Resident res) {
-        IntegerDataField idf = (IntegerDataField) residentLives.clone();
-        if (res.hasMeta(idf.getKey())) {
-            MetaDataUtil.setInt(res, idf, getResidentLives(res) + 1, true);
-        }
-
-        res.save();
-    }
-
     public static void removeResidentLivesMeta(Resident res) {
-        IntegerDataField idf = (IntegerDataField) residentLives.clone();
+        IntegerDataField idf = (IntegerDataField) RESIDENT_LIVES.clone();
         if (res.hasMeta(idf.getKey())) {
             res.removeMetaData(idf, true);
         }
@@ -57,17 +48,17 @@ public class WarDataController {
     }
 
     public static long getLastWarTime(TownyObject obj) {
-        LongDataField ldf = (LongDataField) lastWarEndTime.clone();
+        LongDataField ldf = (LongDataField) LAST_WAR_END_TIME.clone();
         return obj.hasMeta(ldf.getKey()) ? MetaDataUtil.getLong(obj, ldf) : 0L;
     }
 
     public static boolean hasLastWarTime(TownyObject obj) {
-        LongDataField ldf = (LongDataField) lastWarEndTime.clone();
+        LongDataField ldf = (LongDataField) LAST_WAR_END_TIME.clone();
         return obj.hasMeta(ldf.getKey());
     }
 
     public static void setLastWarTime(TownyObject obj, long time) {
-        LongDataField ldf = (LongDataField) lastWarEndTime.clone();
+        LongDataField ldf = (LongDataField) LAST_WAR_END_TIME.clone();
         if (obj.hasMeta(ldf.getKey())) {
             MetaDataUtil.setLong(obj, ldf, time, true);
         } else {
@@ -77,7 +68,7 @@ public class WarDataController {
     }
 
     public static void removeEndTime(TownyObject obj) {
-        LongDataField ldf = (LongDataField) lastWarEndTime.clone();
+        LongDataField ldf = (LongDataField) LAST_WAR_END_TIME.clone();
         if (obj.hasMeta(ldf.getKey())) {
             obj.removeMetaData(ldf, true);
         }
@@ -85,34 +76,16 @@ public class WarDataController {
     }
 
     public static int getWarTokens(TownyObject obj) {
-        IntegerDataField idf = (IntegerDataField) tokens.clone();
+        IntegerDataField idf = (IntegerDataField) TOKENS.clone();
         return obj.hasMeta(idf.getKey()) ? MetaDataUtil.getInt(obj, idf) : 0;
     }
 
     public static void setTokens(TownyObject obj, int num) {
-        IntegerDataField idf = (IntegerDataField) tokens.clone();
+        IntegerDataField idf = (IntegerDataField) TOKENS.clone();
         if (obj.hasMeta(idf.getKey())) {
             MetaDataUtil.setInt(obj, idf, num, true);
         } else {
             obj.addMetaData(new IntegerDataField("unitedwars_tokens", num, "War Tokens"), true);
-        }
-
-    }
-
-    public static void removeTokens(TownyObject obj) {
-        IntegerDataField idf = (IntegerDataField) tokens.clone();
-        if (obj.hasMeta(idf.getKey())) {
-            obj.removeMetaData(idf, true);
-        }
-
-    }
-
-    public static void incrementTokens(TownyObject obj) {
-        IntegerDataField idf = (IntegerDataField) tokens.clone();
-        if (obj.hasMeta(idf.getKey())) {
-            MetaDataUtil.setInt(obj, idf, getWarTokens(obj) + 1, true);
-        } else {
-            obj.addMetaData(new IntegerDataField("unitedwars_tokens", 1, "War Tokens"), true);
         }
 
     }

--- a/UnitedWars/src/main/java/org/unitedlands/wars/war/WarDatabase.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/war/WarDatabase.java
@@ -228,7 +228,7 @@ public class WarDatabase {
     public static War getWar(Player player) {
         for (War war : WARS) {
             Resident resident = getTownyResident(player);
-            if (war.getResidents().contains(resident)) {
+            if (war.getWarParticipants().contains(resident)) {
                 return war;
             }
         }
@@ -270,17 +270,10 @@ public class WarDatabase {
     public static void cleanUpBossBars() {
         for (War war : WarDatabase.getWars()) {
             if (war.hasActiveTimer()) {
-                war.getResidents().forEach(resident -> {
-                    if (resident.getPlayer() != null) {
-                        war.getWarTimer().removeViewer(resident.getPlayer());
-                    }
-                });
+                war.getOnlinePlayers().forEach(player -> war.getWarTimer().removeViewer(player));
             }
 
-            war.getResidents().forEach(resident -> {
-                if (!resident.isOnline())
-                    return;
-                Player player = resident.getPlayer();
+            war.getOnlinePlayers().forEach(player -> {
                 WarringEntity warringEntity = getWarringEntity(player);
                 player.hideBossBar(warringEntity.getWarHealth().getBossBar());
             });

--- a/UnitedWars/src/main/java/org/unitedlands/wars/war/WarDatabase.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/war/WarDatabase.java
@@ -176,9 +176,18 @@ public class WarDatabase {
     }
 
     public static WarringEntity getWarringEntity(Player player) {
-        HashSet<WarringEntity> warringEntities = getWarringEntities();
         Resident resident = Utils.getTownyResident(player);
-        for (WarringEntity warringEntity: warringEntities) {
+        return getWarringEntity(resident);
+    }
+
+    public static WarringEntity getWarringEntity(UUID uuid) {
+        Resident resident = Utils.getTownyResident(uuid);
+        return getWarringEntity(resident);
+    }
+
+    public static WarringEntity getWarringEntity(Resident resident) {
+        HashSet<WarringEntity> warringEntities = getWarringEntities();
+        for (WarringEntity warringEntity : warringEntities) {
             if (warringEntity.getWarParticipants().contains(resident)) {
                 return warringEntity;
             }

--- a/UnitedWars/src/main/java/org/unitedlands/wars/war/WarTimer.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/war/WarTimer.java
@@ -87,7 +87,7 @@ public class WarTimer {
     }
 
     private HashSet<UUID> getViewers() {
-        HashSet<Resident> residents = war.getResidents();
+        HashSet<Resident> residents = war.getWarParticipants();
         viewers = new HashSet<>();
         for (Resident resident : residents) {
             Player player = resident.getPlayer();

--- a/UnitedWars/src/main/java/org/unitedlands/wars/war/WarType.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/war/WarType.java
@@ -1,13 +1,14 @@
 package org.unitedlands.wars.war;
 
 public enum WarType {
-    NATIONWAR(15, 7, "Nation War"),
-    TOWNWAR(10, 4, "Town War");
+    NATIONWAR(20, 7, "Nation War"),
+    TOWNWAR(15, 4, "Town War");
 
 
     private final int baseCost;
     private final int cooldownInDays;
     private final String formattedName;
+
     WarType(int baseCost, int cooldownInDays, String formattedName) {
         this.baseCost = baseCost;
         this.cooldownInDays = cooldownInDays;

--- a/UnitedWars/src/main/java/org/unitedlands/wars/war/WarUtil.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/war/WarUtil.java
@@ -16,8 +16,6 @@ import org.unitedlands.wars.books.data.Declarer;
 import org.unitedlands.wars.books.data.WarTarget;
 import org.unitedlands.wars.books.warbooks.WritableDeclaration;
 import org.unitedlands.wars.war.entities.WarringEntity;
-import org.unitedlands.wars.war.entities.WarringNation;
-import org.unitedlands.wars.war.entities.WarringTown;
 
 import java.util.UUID;
 
@@ -86,17 +84,9 @@ public class WarUtil {
 
     public static WarringEntity getOpposingEntity(WarringEntity entity) {
         War war = entity.getWar();
-        if (entity instanceof WarringTown) {
-            for (WarringTown warringTown: war.getWarringTowns()) {
-                if (warringTown != entity)
-                    return warringTown;
-            }
-        } else {
-            for (WarringNation warringNation: war.getWarringNations()) {
-                if (warringNation != entity)
-                    return warringNation;
-            }
-        }
+        for (WarringEntity warringEntity : war.getWarringEntities())
+            return warringEntity != entity ? warringEntity : null;
+
         return null;
     }
 }

--- a/UnitedWars/src/main/java/org/unitedlands/wars/war/entities/WarringEntity.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/war/entities/WarringEntity.java
@@ -6,6 +6,8 @@ import org.bukkit.entity.Player;
 import org.unitedlands.wars.war.War;
 import org.unitedlands.wars.war.health.WarHealth;
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 
@@ -16,8 +18,8 @@ public interface WarringEntity {
 
     WarHealth getWarHealth();
 
-    List<Resident> getWarParticipants();
-    List<Player> getOnlinePlayers();
+    HashSet<Resident> getWarParticipants();
+    HashSet<Player> getOnlinePlayers();
 
     Government getGovernment();
     Resident getLeader();

--- a/UnitedWars/src/main/java/org/unitedlands/wars/war/entities/WarringNation.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/war/entities/WarringNation.java
@@ -5,25 +5,23 @@ import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
 import org.bukkit.entity.Player;
 import org.unitedlands.wars.UnitedWars;
+import org.unitedlands.wars.Utils;
 import org.unitedlands.wars.war.War;
 import org.unitedlands.wars.war.WarDatabase;
 import org.unitedlands.wars.war.health.WarHealth;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.*;
 
 public class WarringNation implements WarringEntity {
     private final UUID nationUUID;
     private final WarHealth warHealth;
-    private final List<Resident> warringResidents;
+    private final List<UUID> warringResidents;
     private final UUID warUUID;
 
     public WarringNation(Nation nation, WarHealth warHealth, List<Resident> warringResidents, War war) {
         this.nationUUID = nation.getUUID();
         this.warHealth = warHealth;
-        this.warringResidents = warringResidents;
+        this.warringResidents = warringResidents.stream().map(Resident::getUUID).toList();
         this.warUUID = war.getUuid();
         WarDatabase.addWarringNation(this);
     }
@@ -36,14 +34,16 @@ public class WarringNation implements WarringEntity {
     public WarHealth getWarHealth() {
         return warHealth;
     }
-
-    public List<Resident> getWarParticipants() {
-        return warringResidents;
+    @Override
+    public HashSet<Resident> getWarParticipants() {
+        HashSet<Resident> residents = new HashSet<>();
+        warringResidents.forEach(uuid -> residents.add(Utils.getTownyResident(uuid)));
+        return residents;
     }
 
     @Override
-    public List<Player> getOnlinePlayers() {
-        List<Player> players = new ArrayList<>();
+    public HashSet<Player> getOnlinePlayers() {
+        HashSet<Player> players = new HashSet<>();
         getWarParticipants().forEach(resident -> {
             if (resident.getPlayer() != null) {
                 players.add(resident.getPlayer());

--- a/UnitedWars/src/main/java/org/unitedlands/wars/war/entities/WarringTown.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/war/entities/WarringTown.java
@@ -5,25 +5,23 @@ import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import org.bukkit.entity.Player;
 import org.unitedlands.wars.UnitedWars;
+import org.unitedlands.wars.Utils;
 import org.unitedlands.wars.war.War;
 import org.unitedlands.wars.war.WarDatabase;
 import org.unitedlands.wars.war.health.WarHealth;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.*;
 
 public class WarringTown implements WarringEntity {
     private final UUID townUUID;
     private final WarHealth warHealth;
-    private final List<Resident> warringResidents;
+    private final HashSet<UUID> warringResidents;
     private final UUID warUUID;
 
     public WarringTown(Town town, WarHealth warHealth, List<Resident> warringResidents, War war) {
         this.townUUID = town.getUUID();
         this.warHealth = warHealth;
-        this.warringResidents = warringResidents;
+        this.warringResidents = Utils.toUUID(warringResidents);
         this.warUUID = war.getUuid();
         if (townUUID != null && warHealth != null && warUUID != null) {
             WarDatabase.addWarringTown(this);
@@ -40,13 +38,15 @@ public class WarringTown implements WarringEntity {
     }
 
     @Override
-    public List<Resident> getWarParticipants() {
-        return warringResidents;
+    public HashSet<Resident> getWarParticipants() {
+        HashSet<Resident> residents = new HashSet<>();
+        warringResidents.forEach(uuid -> residents.add(Utils.getTownyResident(uuid)));
+        return residents;
     }
 
     @Override
-    public List<Player> getOnlinePlayers() {
-        List<Player> players = new ArrayList<>();
+    public HashSet<Player> getOnlinePlayers() {
+        HashSet<Player> players = new HashSet<>();
         getWarParticipants().forEach(resident -> {
             if (resident.getPlayer() != null) {
                 players.add(resident.getPlayer());


### PR DESCRIPTION
This pull request adds a general cleanup and refactoring of the code base for expand-ability in the future. Some notable changes:

- Refactors the Declarer and WarTarget objects to start using UUIDs for player, town, and nations
- Refactors WarringEntity implementations to store a HashSet of UUIDs instead of a List of players. Less room in memory.
- Refactors Wars to store UUIDs as well.
- Shortens a lot of methods to be more concise.
- Makes better use of the getGovernment method in the WarringEntity interface where possible.
- general Broadcast method in the War object to stop repeating useless loops and checks. DRY.  