### PR TITLE
UnitedWars - v4.1 War Death Rework

### DIFF
--- a/UnitedWars/pom.xml
+++ b/UnitedWars/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.unitedlands.war</groupId>
     <artifactId>UnitedWars</artifactId>
-    <version>4.0-SNAPSHOT</version>
+    <version>4.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>UnitedWars</name>

--- a/UnitedWars/src/main/java/org/unitedlands/wars/listeners/PlayerListener.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/listeners/PlayerListener.java
@@ -1,11 +1,11 @@
 package org.unitedlands.wars.listeners;
 
 import com.palmergames.bukkit.towny.TownyUniverse;
+import com.palmergames.bukkit.towny.object.Government;
 import com.palmergames.bukkit.towny.object.Nation;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.jail.Jail;
-import com.palmergames.bukkit.towny.utils.SpawnUtil;
 import de.jeff_media.angelchest.AngelChest;
 import de.jeff_media.angelchest.AngelChestPlugin;
 import de.jeff_media.angelchest.events.AngelChestSpawnEvent;
@@ -23,8 +23,8 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityResurrectEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.*;
 import org.bukkit.projectiles.ProjectileSource;
 import org.jetbrains.annotations.NotNull;
@@ -34,6 +34,7 @@ import org.unitedlands.wars.Utils;
 import org.unitedlands.wars.war.War;
 import org.unitedlands.wars.war.WarDatabase;
 import org.unitedlands.wars.war.entities.WarringEntity;
+import org.unitedlands.wars.war.health.WarHealth;
 
 import java.util.Optional;
 
@@ -157,42 +158,70 @@ public class PlayerListener implements Listener {
     }
 
     @EventHandler
-    public void onDeath(EntityDeathEvent event) {
-        LivingEntity dead = event.getEntity();
-
-        if (!(dead instanceof Player))
+    public void onPreGraveCreation(AngelChestSpawnPrepareEvent event) {
+        Resident resident = getTownyResident(event.getPlayer());
+        if (resident == null)
             return;
+        if (!resident.hasTown())
+            return;
+        if (WarDatabase.hasWar(resident.getPlayer()) && getResidentLives(resident) > 0) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onDeath(PlayerDeathEvent event) {
+        Player dead = event.getPlayer();
 
         Optional<Player> foundKiller = findKiller(dead);
         if (foundKiller.isEmpty()) {
-            runRegularDeathProccess((Player) dead);
+            runRegularDeathProcess(dead);
+            cancelDeath(event);
             return;
         }
 
         Resident killer = getTownyResident(foundKiller.get());
-        Resident victim = getTownyResident((Player) dead);
+        Resident victim = getTownyResident(dead);
 
-        if (!hasSameWar(killer, victim))
-            return;
-
-        // Killer doesn't have lives, return
-        if (!hasResidentLives(killer) || !hasResidentLives(victim))
+        if (!hasSameWar(killer, victim) || !hasResidentLives(killer) || !hasResidentLives(victim))
             return;
 
         WarringEntity warringEntity = WarDatabase.getWarringEntity(victim.getPlayer());
-        if (warringEntity.getWar().hasActiveTimer())
+        War war = warringEntity.getWar();
+        if (war.hasActiveTimer())
             return;
 
         decreaseHealth(victim, warringEntity);
         playSounds(warringEntity);
+
         if (getResidentLives(victim) == 0) {
             notifyWarKick(victim.getPlayer(), warringEntity);
             jailResident(victim, warringEntity);
             return;
         }
         Component message = getPlayerDeathMessage(warringEntity, killer, victim);
-        warringEntity.getWar().broadcast(message);
+        war.broadcast(message);
+        if (!isHoldingTotem(dead)) {
+            cancelDeath(event);
+        }
     }
+
+
+    private void cancelDeath(PlayerDeathEvent event) {
+        Player dead = event.getPlayer();
+        Resident resident = Utils.getTownyResident(dead);
+
+        if (getResidentLives(resident) == 0) {
+            event.setCancelled(false);
+            return;
+        }
+
+        event.setCancelled(true);
+        dead.setHealth(20.0);
+        dead.setFoodLevel(20);
+        Utils.teleportPlayerToSpawn(dead);
+    }
+
 
     private boolean isHoldingTotem(Player player) {
         return player.getInventory().getItemInMainHand().getType() == Material.TOTEM_OF_UNDYING || player.getInventory().getItemInOffHand().getType() == Material.TOTEM_OF_UNDYING;
@@ -206,42 +235,49 @@ public class PlayerListener implements Listener {
         victim.setJailHours(3);
         victim.save();
         TownyUniverse.getInstance().getJailedResidentMap().add(victim);
-        SpawnUtil.jailTeleport(victim);
+        victim.getPlayer().teleportAsync(victim.getJailSpawn(), PlayerTeleportEvent.TeleportCause.SPECTATE);
         victim.getPlayer().sendMessage(getMessage("you-were-jailed"));
     }
 
     private Jail getJail(WarringEntity warringEntity) {
-        if (warringEntity.getGovernment() instanceof Town town)
-            if (town.hasJails())
-                return town.getPrimaryJail();
-        else {
-            Nation nation = (Nation) warringEntity.getGovernment();
-            if (nation.getCapital().hasJails())
-                return nation.getCapital().getPrimaryJail();
+        Government government = warringEntity.getGovernment();
+
+        if (government instanceof Town town && town.hasJails()) {
+            return town.getPrimaryJail();
+        } else if (government instanceof Nation nation && nation.getCapital().hasJails()) {
+            return nation.getCapital().getPrimaryJail();
         }
+
         return null;
     }
 
-    private void runRegularDeathProccess(Player dead) {
-        Resident resident = getTownyResident(dead);
-        if (!WarDatabase.hasWar(dead))
+    private void runRegularDeathProcess(Player dead) {
+        if (!WarDatabase.hasWar(dead)) {
             return;
-        if (!hasResidentLives(resident))
-            return;
-        WarringEntity warringEntity = WarDatabase.getWarringEntity(dead);
-        if (warringEntity.getWar().hasActiveTimer())
-            return;
-        // Decrease the health by 3
-        warringEntity.getWarHealth().decreaseHealth(3);
-        warringEntity.getWarHealth().flash();
-        warringEntity.getWar().broadcast(getMessage("regular-death",
-                component("victim",
-                        text(dead.getName())),
-                component("victim-warrer",
-                        text(warringEntity.name()))));
-        playSounds(warringEntity);
+        }
 
+        Resident resident = getTownyResident(dead);
+        if (!hasResidentLives(resident)) {
+            return;
+        }
+
+        WarringEntity warringEntity = WarDatabase.getWarringEntity(dead);
+        if (warringEntity.getWar().hasActiveTimer()) {
+            return;
+        }
+
+        int healthDecrease = 3;
+        WarHealth health = warringEntity.getWarHealth();
+        health.decreaseHealth(healthDecrease);
+        health.flash();
+
+        Component message = getMessage("regular-death",
+                component("victim", text(dead.getName())),
+                component("victim-warrer", text(warringEntity.name())));
+        warringEntity.getWar().broadcast(message);
+        playSounds(warringEntity);
     }
+
 
     private void decreaseHealth(Resident victim, WarringEntity warringEntity) {
         warringEntity.getWarHealth().decreaseHealth(5);
@@ -270,9 +306,7 @@ public class PlayerListener implements Listener {
 
     @NotNull
     private Component getPlayerDeathMessage(WarringEntity entity, Resident killer, Resident victim) {
-        String message = "player-killed";
-        if (killer == victim)
-            message = "player-killed-self";
+        String message = killer == victim ? "player-killed-self" : "player-killed";
         return Utils.getMessage(message,
                 component("victim",
                         text(victim.getName())),

--- a/UnitedWars/src/main/java/org/unitedlands/wars/listeners/WarListener.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/listeners/WarListener.java
@@ -152,7 +152,7 @@ public class WarListener implements Listener {
     private void addResidentLives(WarringEntity warringEntity) {
         for (Resident resident: warringEntity.getWarParticipants()) {
             int currentLives = WarDataController.getResidentLives(resident);
-            WarDataController.setResidentLives(resident, Math.min(6, currentLives + 3));
+            WarDataController.setResidentLives(resident, Math.min(3, currentLives + 3));
         }
     }
 


### PR DESCRIPTION
War deaths and lives have gotten a rework again! This was initially how it was supposed to be, but due to some bugs with the system it was rolled back to the old one. 

## Changes
+ Dying in a war now no longer drops your items directly. 
+ Graves only drop (lootable by all) once you expend all your war lives. 
+ On death, your health and hunger is restored, and you're teleported back to your town's spawn, away from conflict, with all your items intact. (if you have war lives of course)

- The maximum of war lives was reduced from 6 to 3 due to this new system. You still get 3 lives every towny day, but it caps at 3 now. This is so items are still easily obtainable without having to go through 6 deaths. 

## Reasoning

We think this system will 
1) Make it less intimidating to participate in a war or start one 
2) Make wars more enjoyable, as now dying once won't ruin your chances of participating again. 
3) Make large battles and fights easier to take place. Previously wars would wrap up very quickly after one side loses most of its gear due to the old 1 death loot system. With this players are still able to hop back into battle and make it more enjoyable for a bit longer. 