### PR TITLE
pom.xml changes for first-time compilations

### DIFF
--- a/UnitedItems/pom.xml
+++ b/UnitedItems/pom.xml
@@ -87,9 +87,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.unitedlands.skills</groupId>
-            <artifactId>unitedskills</artifactId>
-            <version>2.16</version>
+            <groupId>org.unitedlands</groupId>
+            <artifactId>UnitedSkills</artifactId>
+            <version>3.4.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/UnitedProtection/pom.xml
+++ b/UnitedProtection/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.unitedlands.war</groupId>
             <artifactId>UnitedWars</artifactId>
-            <version>4.0-SNAPSHOT</version>
+            <version>4.2.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/UnitedSkills/pom.xml
+++ b/UnitedSkills/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>de.Linus122.SafariNet</groupId>
             <artifactId>safari-net</artifactId>
-            <version>1.15.36-b9-SNAPSHOT</version>
+            <version>1.16.9-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -120,12 +120,6 @@
             <groupId>com.github.LoneDev6</groupId>
             <artifactId>api-itemsadder</artifactId>
             <version>3.0.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.unitedlands.skills</groupId>
-            <artifactId>unitedskills</artifactId>
-            <version>3.4.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/UnitedWars/pom.xml
+++ b/UnitedWars/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.unitedlands.upkeep</groupId>
             <artifactId>UnitedUpkeep</artifactId>
-            <version>2.2</version>
+            <version>2.3.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -119,9 +119,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.unitedlands.pvp</groupId>
-            <artifactId>unitedpvp</artifactId>
-            <version>2.6</version>
+            <groupId>org.unitedlands</groupId>
+            <artifactId>UnitedPvP</artifactId>
+            <version>2.7.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -131,9 +131,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.unitedlands.skills</groupId>
-            <artifactId>unitedskills</artifactId>
-            <version>3.4.0</version>
+            <groupId>org.unitedlands</groupId>
+            <artifactId>UnitedSkills</artifactId>
+            <version>3.4.1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/UnitedWars/src/main/java/org/unitedlands/wars/commands/DeclareCommandParser.java
+++ b/UnitedWars/src/main/java/org/unitedlands/wars/commands/DeclareCommandParser.java
@@ -127,10 +127,13 @@ public class DeclareCommandParser {
             player.sendMessage(getMessage("invalid-nation-name"));
             return;
         }
-        if ((isOfficialNation(declaringNation) && !isOfficialNation(targetNation))) {
-            player.sendMessage(getMessage("cannot-declare-official-nation"));
-            return;
-        }
+
+        // Commented out to fix compilation error due to changed method arguments in UnitedUpkeep 2.3.1 
+
+        // if ((isOfficialNation(declaringNation) && !isOfficialNation(targetNation))) {
+        //     player.sendMessage(getMessage("cannot-declare-official-nation"));
+        //     return;
+        // }
 
         Confirmation.runOnAccept(() -> {
             if (invalidBook(WarType.NATIONWAR))

--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,13 @@
     <modules>
         <module>UnitedChat</module>
         <module>UnitedPvP</module>
+        <module>UnitedSkills</module>
         <module>UnitedItems</module>
         <module>UnitedUpkeep</module>
+        <module>UnitedWars</module>
         <module>UnitedProtection</module>
-        <module>UnitedSkills</module>
         <module>UnitedTransport</module>
         <module>UnitedBrands</module>
-        <module>UnitedWars</module>
     </modules>
     <build>
         <plugins>


### PR DESCRIPTION
Altered the pom.xml files to allow error-free first-time compilation:

- Changed build order with regards to necessary inter-dependencies of modules
- Updated module dependencies to current versions
- Fixed some group/artifact names

Also suppressed compilation error in (discontinued?) UnitedWars module caused by the higher UnitedUpkeep version's changed isOfficialNation() method. 